### PR TITLE
[WIP] Definition of a generally applicable code sniffer standard.

### DIFF
--- a/src/main/Qafoo/Review/Analyzer/CodeSniffer/CodingStandard.php
+++ b/src/main/Qafoo/Review/Analyzer/CodeSniffer/CodingStandard.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Qafoo\Review\Analyzer\CodeSniffer;
+
+class CodingStandard extends PHP_CodeSniffer_Standards_CodingStandard
+{
+    public function getIncludedSniffs()
+    {
+        return array(
+            'Generic/Sniffs/CodeAnalysis/EmptyStatementSniff.php',
+            'Generic/Sniffs/CodeAnalysis/JumbledIncrementerSniff.php',
+            'Generic/Sniffs/CodeAnalysis/UnconditionalIfStatementSniff.php',
+            'Generic/Sniffs/Files/OneClassPerFileSniff.php',
+            'Generic/Sniffs/Files/OneInterfacePerFileSniff.php',
+            'Generic/Sniffs/Functions/CallTimePassByReferenceSniff.php',
+            'Generic/Sniffs/Metrics/NestingLevelSniff.php',
+            'Generic/Sniffs/PHP/DeprecatedFunctionsSniff.php',
+            'Generic/Sniffs/PHP/NoSilencedErrorsSniff.php',
+            'PSR1/Sniffs/Files/SideEffectsSniff.php',
+            'Squiz/Sniffs/PHP/CommentedOutCodeSniff.php',
+            'Squiz/Sniffs/PHP/DiscouragedFunctionsSniff.php',
+            'Squiz/Sniffs/PHP/EvalSniff.php',
+            'Squiz/Sniffs/PHP/GlobalKeywordSniff.php',
+            'Squiz/Sniffs/Scope/StaticThisUsageSniff.php',
+            // extend /usr/share/php/PHP/CodeSniffer/Standards/Squiz/Sniffs/PHP/ForbiddenFunctionsSniff.php
+        );
+    }
+
+    public function getExcludedSniffs()
+    {
+        return array();
+    }
+}


### PR DESCRIPTION
**Do not merge**. This is still work in progress and only pushed in order to safe the current work state and allow others to pick up open tasks.

The collected sniffs are generally applicable and scan for common problems, which are not related to a certain coding standard.

TODO:
- [x] Create standard definition
- [ ] Create PHP_CodeSniffer analyzer
- [ ] Configure analyzer with this sniff by default
